### PR TITLE
Rebuild for new compilers (again)

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: eebb52171a4353aaad01921384098cf54eb96ebfaf99660e017f6d9fc96657a6
 
 build:
-  number: 1001
+  number: 2001
   skip: True  # [win]
 
 requirements:


### PR DESCRIPTION
Due to an issue in ci-scripts, which has been resolved, there was a bad version
number bump in the main channel for this package.

This PR will increase the build number for the new compiler's build by 1000,
allowing them to take precedence when the new compilers are merged with the
main branch.